### PR TITLE
Fix wrong padding offsets and add load&execute support (like QTULOAD)

### DIFF
--- a/ezotgdbg.c
+++ b/ezotgdbg.c
@@ -347,8 +347,8 @@ void write_eeprom_short() {
     sl11r_eeprom_setup();
   size = load_buffer(buf + 8, filename); /* Reserve space for SCAN header. */
   /* pad payload by another 2 bytes (4 total, based on observations) */
-  buf[size + 1] = 0x00;
-  buf[size + 2] = 0x00;
+  buf[size + 8] = 0x00;
+  buf[size + 9] = 0x00;
   size += 2;
   /* SCAN header signature */
   buf[0] = 0xB6;

--- a/ezotgdbg.c
+++ b/ezotgdbg.c
@@ -137,6 +137,7 @@ void print_usage(int argc, char *argv[]) {
   printf("      -m\tWrite contents of (small) FILE to EEPROM.\n");
   printf("      -o\tOffset in RAM to read from.\n");
   printf("      -n\tNumber of bytes (to read.)\n");
+  printf("      -x\tLoad FILE into RAM and execute (like QTULOAD).\n");
   printf("      -h\tShow this help screen.\n");
   printf("\n");
 }
@@ -381,11 +382,49 @@ void write_eeprom_short() {
 }
 
 
+void load_exec() {
+  int size, write_res;
+  usb_connect();
+  size = load_buffer(buf + 6, filename); /* Reserve space for SCAN header. */
+  /* SCAN header signature */
+  buf[0] = 0xB6;
+  buf[1] = 0xC3;
+  /* Payload size */
+  buf[2] = 0xFF & (size - 1);	/* size was incremented by 2 by load_buffer() */
+  buf[3] = (0xFF00 & (size - 1)) >> 8;
+  /* operation: alloc memory to vector & load code */
+  buf[4] = 0x02;
+  /* Destination vector */
+  buf[5] = 0x52;
+  /* Adjust byte count to fit SCAN header. */
+  size += 6;
+  /* Send payload. */
+  write_res = usb_control_msg(devh, USB_ENDPOINT_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
+			      CY_REQUEST_CODE, 0x02, 0x4d0,
+			      buf, size, TIMEOUT);
+
+  if (write_res != size) {
+    printf("Error writing to RAM: %d bytes sent out of %d bytes attempted.\n",
+	   write_res, size);
+    usb_disconnect();
+    exit(1);
+  }
+  printf("%d bytes wrote to RAM from '%s'.\n", size, filename);
+
+  char cmd[] = { 0xb6, 0xc3, 0x01, 0x00, 0x06, 0x52, 0x00, 0x00 }; /* execute vector 0x52 */
+  usb_control_msg(devh, USB_ENDPOINT_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
+                  CY_REQUEST_CODE, 0x06, 0x4d0,
+                  cmd, sizeof(cmd), TIMEOUT);
+
+  usb_disconnect();
+}
+
+
 /* TODO: implement writing. */
 int main(int argc, char *argv[]) {
   int ok;
   char c;
-  while ((c = getopt(argc, argv, "o:n:r:w:m:h|help")) != -1) {
+  while ((c = getopt(argc, argv, "o:n:r:w:m:x:h|help")) != -1) {
     switch(c) {
     case 'o':
       /* offset = atoi(optarg); */
@@ -417,6 +456,11 @@ int main(int argc, char *argv[]) {
     case 'm':
       filename = optarg;
       write_eeprom_short();
+      exit(0);
+      break;
+    case 'x':
+      filename = optarg;
+      load_exec();
       exit(0);
       break;
     case 'h':

--- a/ezotgdbg.c
+++ b/ezotgdbg.c
@@ -183,8 +183,8 @@ int load_buffer(char *buffer, char *file_name) {
     exit(1);
   }
   /* Pad buffer */
+  buffer[fsize] = 0x00;
   buffer[fsize + 1] = 0x00;
-  buffer[fsize + 2] = 0x00;
   fsize += 2;
   return fsize;
 }


### PR DESCRIPTION
There are two wrong padding offsets, one of them corrupts code loaded into EEPROM.
Add support for loading code into RAM and executing (like QTULOAD). Don't know if it works with CY7C67300.